### PR TITLE
Term meta improvements

### DIFF
--- a/hm-core.termmeta.php
+++ b/hm-core.termmeta.php
@@ -82,6 +82,22 @@ function delete_term_meta( $term_id, $meta_key, $meta_value = '' ) {
 }
 endif;
 
+/**
+ * Hook into the delete_term action and make sure any meta is also delete
+ * @param int $term_id
+ */
+function delete_term_meta_when_term_is_deleted( $term_id ) {
+
+	global $wpdb;
+
+	$term_meta_ids = $wpdb->get_col( $wpdb->prepare( "SELECT meta_id FROM $wpdb->termmeta WHERE term_id = %d ", $term_id ) );
+
+	foreach ( $term_meta_ids as $mid )
+		delete_metadata_by_mid( 'term', $mid );
+
+}
+add_action ( 'delete_term', 'delete_term_meta_when_term_is_deleted' );
+
 if ( ! function_exists( 'get_term_meta' ) ) :
 /**
  * Retrieve term meta field for a term.


### PR DESCRIPTION
Several improvements to the our term meta polyfill. Maybe we should consider splitting this into it's own repo?

Here's what I fixed
- [x] Code formatting and PHPDocs
- [x] The `CREATE TABLE` query now does a `CREATE TABLE IF NOT EXISTS` so as to avoid a warning if the table does actually exist
- [x] Instead of manually specifying `ENGINE=MyISAM` the `CREATE TABLE` query now specifies `ENGINE=`DEFAULT`` so that the table is created with the default storage engine.
- [x] Up to now we haven't been deleting any term meta when the associated term was deleted, I've fixed this oversight by hooking into the `delete_term` hook.
